### PR TITLE
Fix build on macOS

### DIFF
--- a/ncls/src/cncls.pxd
+++ b/ncls/src/cncls.pxd
@@ -37,7 +37,7 @@ cdef extern from "stdio.h":
 #   char *strcat(char *,char *)
 
 
-cdef extern from "ncls/src/intervaldb.h":
+cdef extern from "intervaldb.h":
     ctypedef struct IntervalMap:
         int start
         int end

--- a/ncls/src/ncls.c
+++ b/ncls/src/ncls.c
@@ -579,7 +579,7 @@ static CYTHON_INLINE float __PYX_NAN() {
 /* Early includes */
 #include "stdlib.h"
 #include "stdio.h"
-#include "ncls/src/intervaldb.h"
+#include "intervaldb.h"
 #include <string.h>
 #include <stdlib.h>
 #include "pythread.h"


### PR DESCRIPTION
Solves #3 by fixing the include path for the header file. I haven't tested on other systems, so hopefully it doesn't break the build on other OSs.