### PR TITLE
Add missing functions in header files.

### DIFF
--- a/ncls/src/intervaldb.h
+++ b/ncls/src/intervaldb.h
@@ -78,6 +78,7 @@ typedef struct {
 extern int *alloc_array(int n);
 
 extern int64_t find_overlap_start(int64_t start,int64_t end,IntervalMap im[],int n);
+extern int find_suboverlap_start(int start,int end,int isub,IntervalMap im[],SublistHeader subheader[]);
 extern int imstart_qsort_cmp(const void *void_a,const void *void_b);
 extern int target_qsort_cmp(const void *void_a,const void *void_b);
 extern IntervalMap *read_intervals(int n,FILE *ifile);

--- a/ncls/src/intervaldb32.h
+++ b/ncls/src/intervaldb32.h
@@ -38,6 +38,7 @@ typedef struct IntervalIterator_S {
 extern int *alloc_array(int n);
 
 extern int find_overlap_start(int start,int end,IntervalMap im[],int n);
+extern int find_suboverlap_start(int start,int end,int isub,IntervalMap im[],SublistHeader subheader[]);
 extern int imstart_qsort_cmp(const void *void_a,const void *void_b);
 extern int target_qsort_cmp(const void *void_a,const void *void_b);
 extern SublistHeader *build_nested_list(IntervalMap im[],int n,


### PR DESCRIPTION
Thanks for the library, it looks like a very promising alternative to interval trees!

I had a small issue installing it on Ubuntu 18, which I believe this PR addresses.

Before this change, calling `python -c "import ncls"` after build caused error `.../ncls.cpython-37m-x86_64-linux-gnu.so: undefined symbol: find_suboverlap_start`