### PR TITLE
Fix for building and passing tests for 32-bit archs

### DIFF
--- a/tests/test_ncls.py
+++ b/tests/test_ncls.py
@@ -46,12 +46,10 @@ if struct.calcsize("P") * 8 == 64:
         assert list(subs) == [0, 1] == list(covers)
 
 else:
-    
-    starts = np.array([5, 2_147_483_645], dtype=np.int32)
 
-    ends = np.array([6, 2_147_483_646], dtype=np.int32)
-
-    ids = np.array([0, 3], dtype=np.int32)
+    starts = np.array([5, 2_147_483_645], dtype=np.int64)
+    ends = np.array([6, 2_147_483_646], dtype=np.int64)
+    ids = np.array([0, 3], dtype=np.int64)
 
     def test_ncls():
         # ids = starts
@@ -71,9 +69,9 @@ else:
 
     def test_all_containments_both():
 
-        starts = np.array([5, 10], dtype=np.int32)
-        ends = np.array([6, 50], dtype=np.int32)
-        ids = np.array([0, 1], dtype=np.int32)
+        starts = np.array([5, 10], dtype=np.int64)
+        ends = np.array([6, 50], dtype=np.int64)
+        ids = np.array([0, 1], dtype=np.int64)
 
         ncls = NCLS(starts, ends, ids)
         subs, covers = ncls.all_containments_both(starts, ends, ids)


### PR DESCRIPTION
Hi,

I suppose NCLS is compatible to run with 32-bit archs right?

The tests actually seem to fail with those archs due to very large values as well as type mismatch at a couple of points.
This is my attempt to fix it.

I tried testing it in a 32-bit environment and it works.